### PR TITLE
Use Resource::Wrangler for handling resource paths

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -5,7 +5,8 @@
   ],
   "build-depends": [
     "PathTools",
-    "JSON::Fast"
+    "JSON::Fast",
+    "Resource::Wrangler"
   ],
   "depends": [
   ],
@@ -45,5 +46,5 @@
   ],
   "test-depends": [
   ],
-  "version": "0.2.4"
+  "version": "0.2.5"
 }

--- a/META6.json
+++ b/META6.json
@@ -5,10 +5,10 @@
   ],
   "build-depends": [
     "PathTools",
-    "JSON::Fast",
-    "Resource::Wrangler"
+    "JSON::Fast"
   ],
   "depends": [
+    "Resource::Wrangler:ver<1.1.1+>"
   ],
   "description": "OpenSSL bindings",
   "license": "MIT",
@@ -46,5 +46,5 @@
   ],
   "test-depends": [
   ],
-  "version": "0.2.5"
+  "version": "0.2.4"
 }

--- a/lib/OpenSSL/NativeLib.rakumod
+++ b/lib/OpenSSL/NativeLib.rakumod
@@ -1,5 +1,7 @@
 unit module OpenSSL::NativeLib;
 
+use Resource::Wrangler;
+
 BEGIN my %libraries = Rakudo::Internals::JSON.from-json: %?RESOURCES<libraries.json>.slurp(:close);
 
 sub ssl-lib is export {
@@ -28,20 +30,8 @@ sub crypto-lib is export {
 # and use it if it exists, otherwise copy the name mangled file to this location but using the
 # original unmangled name.
 # XXX: This should be removed when CURI/%?RESOURCES gets a mechanism to bypass name mangling
-use nqp;
 sub dll-resource($resource-name) {
-    my $content-id    = nqp::sha1($resource-name);
-    my $dll-directory = $*TMPDIR.add($content-id);
-    my $dll-resource  = $dll-directory.add($resource-name);
-
-    unless $dll-resource.e {
-        mkdir $dll-directory unless $dll-directory.e;
-        my $resource = %?RESOURCES{$resource-name};
-        my $resource-data := %?RESOURCES{$resource-name}.slurp(:bin, :close);
-        $dll-resource.spurt($resource-data, :bin, :close);
-    }
-
-    $dll-resource.absolute
+    load-resource-to-path($resource-name).absolute
 }
 
 # vim: expandtab shiftwidth=4

--- a/lib/OpenSSL/NativeLib.rakumod
+++ b/lib/OpenSSL/NativeLib.rakumod
@@ -31,7 +31,8 @@ sub crypto-lib is export {
 # original unmangled name.
 # XXX: This should be removed when CURI/%?RESOURCES gets a mechanism to bypass name mangling
 sub dll-resource($resource-name) {
-    load-resource-to-path($resource-name).absolute
+    my $prefix = $*TMPDIR.add($?DISTRIBUTION.Str);
+    load-resource-to-path($resource-name, :$prefix, :filename($resource-name)).absolute
 }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
This simplifies the code and removes the necessity to worry over the details of using temporary files for accessing resources.